### PR TITLE
Feature: Add release age to npmrc for security

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,4 @@
+# Pin dependencies for security.
 save-exact=true
+# Give new packages time to get vetted before use.
+min-release-age=7

--- a/README.md
+++ b/README.md
@@ -7,18 +7,17 @@ A simple starter for frontend projects with basic setup and best practices.
 You can also use these as references for your own projects.
 
 - `.nvmrc` file for using the latest Node.js LTS version
-- `.npmrc` file to lock dependency versions for better security
+- `.npmrc` file to pin dependencies and delay installing newly published package
 - `.editorconfig` for consistent code formatting
 
 ### Demos
 
 Included are demo branches you can use or reference to help you setup specific tools. Included branches:
 
-| Branch name | Description |
--- | ---
-`feature/ci-example` | CI workflows with linting, formatting, and a11y checks.
-`feature/vite-uswds` | USWDS, Vite, and modern SASS api setup.
-
+| Branch name          | Description                                             |
+| -------------------- | ------------------------------------------------------- |
+| `feature/ci-example` | CI workflows with linting, formatting, and a11y checks. |
+| `feature/vite-uswds` | USWDS, Vite, and modern SASS api setup.                 |
 
 ## How to use this template
 


### PR DESCRIPTION
<!-- Welcome and thanks for creating a pull request! -->
<!-- Please fill out the information below. -->

## Description

For security, updated npmrc to add a delay for installing newly published packages. This way they can get tested before installing.

## Related Issues

n/a

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Other (please explain):

## How did you test?

I installed and tested on the vite/uswds branch without any issues.

## Checklist

- [x] I've done a self-review of my code
- [x] I've updated the docs
